### PR TITLE
Support for nwer versions of bcrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ The WordPress passwords can be inserted directly into the CREDENTIALS table in K
 | :-- | :-- |
 | {"value":"$2y$10$Ma/RzN/J089o4gCs1MbzcOTvkbGXvmkEJXwNh3a3Bj1ZTnlwi93u.","salt":""} | {"hashIterations":-1,"algorithm":"bcrypt"}|
 
-Please note that the hashIterations must either be -1 or match the defualt set up in keycloak.
+Please note that the hashIterations must either be -1 or match the default set up in keycloak.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ mvn clean package
 
 ## Install
 ```
-curl https://repo1.maven.org/maven2/at/favre/lib/bcrypt/0.9.0/bcrypt-0.9.0.jar > bcrypt-0.9.0.jar
-KEYCLOAK_HOME/bin/jboss-cli.sh --command="module add --name=at.favre.lib.jbcrypt --resources=bcrypt-0.9.0.jar"
 curl -L https://github.com/leroyguillaume/keycloak-bcrypt/releases/download/1.3.0/keycloak-bcrypt-1.3.0.jar > KEYCLOAK_HOME/standalone/deployments/keycloak-bcrypt-1.3.0.jar
 ```
 You need to restart Keycloak.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Add a password hash provider to handle BCrypt passwords inside Keycloak.
 
+The password provider supports all current versions of bcrypt. For details please refer to [https://en.wikipedia.org/wiki/Bcrypt].
+
 ## Build
 ```
 mvn clean package
@@ -44,3 +46,13 @@ keycloak:
       - ./keycloak/bcrypt/dependency/jbcrypt:/opt/jboss/keycloak/modules/org/mindrot/jbcrypt/main
       - ./keycloak/bcrypt/deployments:/opt/jboss/keycloak/standalone/deployments
 ```
+
+## Porting WordPress users to KeyCloak
+This module can be used to port an existing user database from WordPress internal database to KeyCloak without the need for new user passwords.
+The WordPress passwords can be inserted directly into the CREDENTIALS table in KeyCloak. Below is an example of the two columns in the database:
+
+| SECRET_DATA | CREDENTIAL_DATA |
+| :-- | :-- |
+| {"value":"$2y$10$Ma/RzN/J089o4gCs1MbzcOTvkbGXvmkEJXwNh3a3Bj1ZTnlwi93u.","salt":""} | {"hashIterations":-1,"algorithm":"bcrypt"}|
+
+Please note that the hashIterations must either be -1 or match the defualt set up in keycloak.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ mvn clean package
 
 ## Install
 ```
-curl https://repo1.maven.org/maven2/org/mindrot/jbcrypt/0.4/jbcrypt-0.4.jar > jbcrypt-0.4.jar
-KEYCLOAK_HOME/bin/jboss-cli.sh --command="module add --name=org.mindrot.jbcrypt --resources=jbcrypt-0.4.jar"
-curl -L https://github.com/leroyguillaume/keycloak-bcrypt/releases/download/1.2.0/keycloak-bcrypt-1.2.0.jar > KEYCLOAK_HOME/standalone/deployments/keycloak-bcrypt-1.2.0.jar
+curl https://repo1.maven.org/maven2/at/favre/lib/bcrypt/0.9.0/bcrypt-0.9.0.jar > bcrypt-0.9.0.jar
+KEYCLOAK_HOME/bin/jboss-cli.sh --command="module add --name=at.favre.lib.jbcrypt --resources=bcrypt-0.9.0.jar"
+curl -L https://github.com/leroyguillaume/keycloak-bcrypt/releases/download/1.3.0/keycloak-bcrypt-1.3.0.jar > KEYCLOAK_HOME/standalone/deployments/keycloak-bcrypt-1.3.0.jar
 ```
 You need to restart Keycloak.
 
@@ -22,19 +22,19 @@ You need to restart Keycloak.
 Add the following `module.xml` file in directory created above:
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<module xmlns="urn:jboss:module:1.5" name="org.mindrot.jbcrypt">
+<module xmlns="urn:jboss:module:1.5" name="at.favre.lib.jbcrypt">
     <resources>
-        <resource-root path="jbcrypt-0.4.jar"/>
+        <resource-root path="bcrypt-0.9.0.jar"/>
     </resources>
 </module>
 ```
 
-`curl https://repo1.maven.org/maven2/org/mindrot/jbcrypt/0.4/jbcrypt-0.4.jar > ./keycloak/bcrypt/dependency/jbcryptjbcrypt-0.4.jar`
+`https://repo1.maven.org/maven2/at/favre/lib/bcrypt/0.9.0/bcrypt-0.9.0.jar > ./keycloak/bcrypt/dependency/bcrypt-0.9.0.jar`
 
 
 `mkdir -p ./keycloak/bcrypt/deployments`
 
-`curl -L https://github.com/leroyguillaume/keycloak-bcrypt/releases/download/1.2.0/keycloak-bcrypt-1.2.0.jar > ./keycloak/bcrypt/deployments`
+`curl -L https://github.com/leroyguillaume/keycloak-bcrypt/releases/download/1.3.0/keycloak-bcrypt-1.3.0.jar > ./keycloak/bcrypt/deployments`
 
 
 docker-compose.yml

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.leroyguillaume</groupId>
     <artifactId>keycloak-bcrypt</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
 
     <properties>
         <!-- Maven -->
@@ -14,18 +14,40 @@
         <maven.compiler.source>1.8</maven.compiler.source>
 
         <!-- Dependencies -->
-        <jbcrypt.version>0.4</jbcrypt.version>
+        <bcrypt.version>0.9.0</bcrypt.version>
         <jboss.logging.version>3.4.1.Final</jboss.logging.version>
         <keycloak.version>8.0.1</keycloak.version>
     </properties>
 
+    <build>
+        <plugins>
+        <plugin>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <version>3.2.0</version>
+            <configuration>
+                <descriptorRefs>
+                    <descriptorRef>jar-with-dependencies</descriptorRef>
+                </descriptorRefs>
+                <appendAssemblyId>false</appendAssemblyId>
+            </configuration>
+            <executions>
+                <execution>
+                    <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                    <phase>package</phase> <!-- bind to the packaging phase -->
+                    <goals>
+                        <goal>single</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+        </plugins>
+    </build>
     <dependencies>
-        <!-- jBCrypt -->
+        <!-- https://mvnrepository.com/artifact/at.favre.lib/bcrypt -->
         <dependency>
-            <groupId>org.mindrot</groupId>
-            <artifactId>jbcrypt</artifactId>
-            <version>${jbcrypt.version}</version>
-            <scope>provided</scope>
+            <groupId>at.favre.lib</groupId>
+            <artifactId>bcrypt</artifactId>
+            <version>${bcrypt.version}</version>
         </dependency>
 
         <!-- JBoss -->
@@ -33,6 +55,7 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
             <version>${jboss.logging.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Keycloak -->
@@ -61,4 +84,5 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
 </project>

--- a/src/main/java/com/github/leroyguillaume/keycloak/bcrypt/BCryptPasswordHashProvider.java
+++ b/src/main/java/com/github/leroyguillaume/keycloak/bcrypt/BCryptPasswordHashProvider.java
@@ -4,7 +4,10 @@ import org.jboss.logging.Logger;
 import org.keycloak.models.credential.PasswordCredentialModel;
 import org.keycloak.credential.hash.PasswordHashProvider;
 import org.keycloak.models.PasswordPolicy;
-import org.mindrot.jbcrypt.BCrypt;
+import at.favre.lib.crypto.bcrypt.BCrypt;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 
 /**
  * @author <a href="mailto:pro.guillaume.leroy@gmail.com">Guillaume Leroy</a>
@@ -17,7 +20,7 @@ public class BCryptPasswordHashProvider implements PasswordHashProvider {
     private final int defaultIterations;
     private final String providerId;
 
-    public BCryptPasswordHashProvider(String providerId, int defaultIterations) {
+    BCryptPasswordHashProvider(String providerId, int defaultIterations) {
         this.providerId = providerId;
         this.defaultIterations = defaultIterations;
     }
@@ -29,8 +32,9 @@ public class BCryptPasswordHashProvider implements PasswordHashProvider {
             policyHashIterations = defaultIterations;
         }
 
-        return credential.getPasswordCredentialData().getHashIterations() == policyHashIterations
-                && providerId.equals(credential.getPasswordCredentialData().getAlgorithm());
+        return (credential.getPasswordCredentialData().getHashIterations() == policyHashIterations ||
+                credential.getPasswordCredentialData().getHashIterations() == -1)
+                        && providerId.equals(credential.getPasswordCredentialData().getAlgorithm());
     }
 
     @Override
@@ -44,7 +48,8 @@ public class BCryptPasswordHashProvider implements PasswordHashProvider {
     @Override
     public String encode(String rawPassword, int iterations) {
         String salt = generateBCryptSalt(iterations);
-        return BCrypt.hashpw(rawPassword, salt);
+        //return BCrypt.hashpw(rawPassword, salt);
+        return BCrypt.with(BCrypt.Version.VERSION_2Y).hashToString(iterations, rawPassword.toCharArray());
     }
 
     @Override
@@ -54,12 +59,22 @@ public class BCryptPasswordHashProvider implements PasswordHashProvider {
 
     @Override
     public boolean verify(String rawPassword, PasswordCredentialModel credential) {
-        return BCrypt.checkpw(rawPassword, credential.getPasswordSecretData().getValue());
+        final String hash = credential.getPasswordSecretData().getValue();
+        BCrypt.Result verifier = BCrypt.verifyer().verify(rawPassword.toCharArray(), hash.toCharArray());
+        return verifier.verified;
     }
 
     private String generateBCryptSalt(int iterations) {
-        int logRounds = iterations == -1 ? iterationsToLogRounds(defaultIterations) : iterationsToLogRounds(iterations);
-        return BCrypt.gensalt(logRounds);
+        final int logRounds = iterations == -1 ? iterationsToLogRounds(defaultIterations) : iterationsToLogRounds(iterations);
+        SecureRandom rnd;
+        try {
+            rnd= SecureRandom.getInstanceStrong();
+        } catch (NoSuchAlgorithmException e) {
+            rnd = new SecureRandom();
+        }
+        rnd.setSeed(logRounds);
+
+        return rnd.toString();
     }
 
     private int iterationsToLogRounds(int iterations) {

--- a/third-party.txt
+++ b/third-party.txt
@@ -1,0 +1,11 @@
+This document contains the list of Third Party Software included with
+keycloak-bcrypt, along with the license information.
+
+Third Party Software may impose additional restrictions and it is the
+user's responsibility to ensure that they have met the licensing
+requirements of PhantomJS and the relevant license of the Third Party
+Software they are using.
+
+at.favre.lib/bcrypt
+License:   Apache License 2.0
+Reference: https://github.com/patrickfav/bcrypt/blob/master/LICENSE


### PR DESCRIPTION
Hi,
I have made a version that uses at.favre.lib.bcrypt instead of the old library. This was to allow for porting of WordPress users into KeyCloak without having them to create new passwords.

At the same time the bcrypt library is linked into the module. This bloats the module, but makes installation simpler. 

/telling