### PR TITLE
Replace Bcrypt package with JBcrypt-0.4.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,13 +16,13 @@ configurations {
 }
 
 dependencies {
-    val bcryptVersion = "0.9.0"
+    val bcryptVersion = "0.4.3"
     val jbossLoggingVersion = "3.4.1.Final"
     val keycloakVersion = project.property("dependency.keycloak.version")
     val junitVersion = "5.8.2"
 
     // BCrypt
-    implementation("at.favre.lib:bcrypt:$bcryptVersion")
+    implementation("de.svenkubiak:jBCrypt:$bcryptVersion")
 
     // JBoss
     compileOnly("org.jboss.logging:jboss-logging:$jbossLoggingVersion")

--- a/src/main/java/com/github/leroyguillaume/keycloak/bcrypt/BCryptPasswordHashProvider.java
+++ b/src/main/java/com/github/leroyguillaume/keycloak/bcrypt/BCryptPasswordHashProvider.java
@@ -1,10 +1,9 @@
 package com.github.leroyguillaume.keycloak.bcrypt;
 
-import at.favre.lib.crypto.bcrypt.BCrypt;
+import org.mindrot.jbcrypt.BCrypt;
 import org.keycloak.credential.hash.PasswordHashProvider;
 import org.keycloak.models.PasswordPolicy;
 import org.keycloak.models.credential.PasswordCredentialModel;
-
 import java.util.Base64;
 
 /**
@@ -38,7 +37,7 @@ public class BCryptPasswordHashProvider implements PasswordHashProvider {
     @Override
     public String encode(final String rawPassword, final int iterations) {
         final int cost = iterations == -1 ? defaultIterations : iterations;
-        return BCrypt.with(BCrypt.Version.VERSION_2Y).hashToString(cost, rawPassword.toCharArray());
+        return BCrypt.hashpw(rawPassword, BCrypt.gensalt(cost));
     }
 
     @Override
@@ -49,7 +48,6 @@ public class BCryptPasswordHashProvider implements PasswordHashProvider {
     @Override
     public boolean verify(final String rawPassword, final PasswordCredentialModel credential) {
         final String hash = credential.getPasswordSecretData().getValue();
-        final BCrypt.Result verifier = BCrypt.verifyer().verify(rawPassword.toCharArray(), hash.toCharArray());
-        return verifier.verified;
+        return BCrypt.checkpw(rawPassword, hash);
     }
 }

--- a/src/main/java/com/github/leroyguillaume/keycloak/bcrypt/BCryptPasswordHashProvider.java
+++ b/src/main/java/com/github/leroyguillaume/keycloak/bcrypt/BCryptPasswordHashProvider.java
@@ -48,6 +48,10 @@ public class BCryptPasswordHashProvider implements PasswordHashProvider {
     @Override
     public boolean verify(final String rawPassword, final PasswordCredentialModel credential) {
         final String hash = credential.getPasswordSecretData().getValue();
-        return BCrypt.checkpw(rawPassword, hash);
+        if (BCrypt.checkpw(rawPassword, hash)){
+            return true;
+        }else{
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Latest version of BCrypt is having Vulnerability as mentioned in Maven -- https://mvnrepository.com/artifact/at.favre.lib/bcrypt/0.9.0

Replaced BCrypt with JBCrypt -- https://mvnrepository.com/artifact/de.svenkubiak/jBCrypt 