### PR TITLE
fix: specify bcrypt version and allow 72 Bytes passwords

### DIFF
--- a/src/main/java/com/github/leroyguillaume/keycloak/bcrypt/BCryptPasswordHashProvider.java
+++ b/src/main/java/com/github/leroyguillaume/keycloak/bcrypt/BCryptPasswordHashProvider.java
@@ -38,7 +38,7 @@ public class BCryptPasswordHashProvider implements PasswordHashProvider {
     @Override
     public String encode(final String rawPassword, final int iterations) {
         final int cost = iterations == -1 ? defaultIterations : iterations;
-        return BCrypt.with(BCrypt.Version.VERSION_2Y).hashToString(cost, rawPassword.toCharArray());
+        return BCrypt.with(BCrypt.Version.VERSION_2Y_NO_NULL_TERMINATOR).hashToString(cost, rawPassword.toCharArray());
     }
 
     @Override
@@ -49,7 +49,7 @@ public class BCryptPasswordHashProvider implements PasswordHashProvider {
     @Override
     public boolean verify(final String rawPassword, final PasswordCredentialModel credential) {
         final String hash = credential.getPasswordSecretData().getValue();
-        final BCrypt.Result verifier = BCrypt.verifyer().verify(rawPassword.toCharArray(), hash.toCharArray());
+        final BCrypt.Result verifier = BCrypt.verifyer(BCrypt.Version.VERSION_2Y_NO_NULL_TERMINATOR).verify(rawPassword.toCharArray(), hash.toCharArray());
         return verifier.verified;
     }
 }

--- a/src/main/java/com/github/leroyguillaume/keycloak/bcrypt/BCryptPasswordHashProvider.java
+++ b/src/main/java/com/github/leroyguillaume/keycloak/bcrypt/BCryptPasswordHashProvider.java
@@ -5,7 +5,6 @@ import org.keycloak.credential.hash.PasswordHashProvider;
 import org.keycloak.models.PasswordPolicy;
 import org.keycloak.models.credential.PasswordCredentialModel;
 
-import java.util.Base64;
 
 /**
  * @author <a href="mailto:pro.guillaume.leroy@gmail.com">Guillaume Leroy</a>


### PR DESCRIPTION
Hi and thanks for your work.

I'd like to propose you two fixes in this PR:
- In [this commit](https://github.com/leroyguillaume/keycloak-bcrypt/commit/00f2e36b84d6c37c254eb7bdb1445270b625a76b) you removed the explicit version from the verifier. If I'm not wrong, the default of the bcrypt package is `VERSION_2A`, so we have a mismatch between hashing and verifying steps.

- For legacy reasons, in `VERSION_2Y`, the Java BCrypt package reserves a byte for the null terminator, and allows a maximum of 71 bytes. 
It also raises an error when the password exceeds the length. 
However, the BCrypt standard allows 72 bytes max. 
On our side, all the password are prehashed, and have a length of exactly 72 bytes (as the standard states). While using your provider, all our passwords fail.
Using the `VERSION_2Y_NO_NULL_TERMINATOR` version should resolve the issue.

Thanks again for your work, and your help.
Matt'.