### PR TITLE
Fix 1.5.2 breaking change

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ configurations {
 }
 
 dependencies {
-    val bcryptVersion = "0.9.0"
+    val bcryptVersion = "0.10.2"
     val jbossLoggingVersion = "3.4.1.Final"
     val keycloakVersion = project.property("dependency.keycloak.version")
     val junitVersion = "5.8.2"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "com.github.leroyguillaume"
-version = "1.5.2"
+version = "1.5.3"
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/github/leroyguillaume/keycloak/bcrypt/BCryptPasswordHashProvider.java
+++ b/src/main/java/com/github/leroyguillaume/keycloak/bcrypt/BCryptPasswordHashProvider.java
@@ -37,7 +37,7 @@ public class BCryptPasswordHashProvider implements PasswordHashProvider {
     @Override
     public String encode(final String rawPassword, final int iterations) {
         final int cost = iterations == -1 ? defaultIterations : iterations;
-        return BCrypt.with(BCrypt.Version.VERSION_2Y_NO_NULL_TERMINATOR).hashToString(cost, rawPassword.toCharArray());
+        return BCrypt.with(BCrypt.Version.VERSION_2Y).hashToString(cost, rawPassword.toCharArray());
     }
 
     @Override
@@ -48,7 +48,7 @@ public class BCryptPasswordHashProvider implements PasswordHashProvider {
     @Override
     public boolean verify(final String rawPassword, final PasswordCredentialModel credential) {
         final String hash = credential.getPasswordSecretData().getValue();
-        final BCrypt.Result verifier = BCrypt.verifyer(BCrypt.Version.VERSION_2Y_NO_NULL_TERMINATOR).verify(rawPassword.toCharArray(), hash.toCharArray());
+        final BCrypt.Result verifier = BCrypt.verifyer(BCrypt.Version.VERSION_2Y).verify(rawPassword.toCharArray(), hash.toCharArray());
         return verifier.verified;
     }
 }

--- a/src/main/java/com/github/leroyguillaume/keycloak/bcrypt/BCryptPasswordHashProvider.java
+++ b/src/main/java/com/github/leroyguillaume/keycloak/bcrypt/BCryptPasswordHashProvider.java
@@ -37,7 +37,7 @@ public class BCryptPasswordHashProvider implements PasswordHashProvider {
     @Override
     public String encode(final String rawPassword, final int iterations) {
         final int cost = iterations == -1 ? defaultIterations : iterations;
-        return BCrypt.with(BCrypt.Version.VERSION_2Y).hashToString(cost, rawPassword.toCharArray());
+        return BCrypt.with(BCrypt.Version.VERSION_2A).hashToString(cost, rawPassword.toCharArray());
     }
 
     @Override
@@ -48,7 +48,7 @@ public class BCryptPasswordHashProvider implements PasswordHashProvider {
     @Override
     public boolean verify(final String rawPassword, final PasswordCredentialModel credential) {
         final String hash = credential.getPasswordSecretData().getValue();
-        final BCrypt.Result verifier = BCrypt.verifyer(BCrypt.Version.VERSION_2Y).verify(rawPassword.toCharArray(), hash.toCharArray());
+        final BCrypt.Result verifier = BCrypt.verifyer(BCrypt.Version.VERSION_2A).verify(rawPassword.toCharArray(), hash.toCharArray());
         return verifier.verified;
     }
 }


### PR DESCRIPTION
Hi,

Following #32 and #33, this PR:
- Updates the version of the upstream BCrypt package (we merged a PR resolving the issue there)
- Removes the usage of custom `NO_NULL_TERMINATOR` version
- Replaces the PHP custom `VERSION_2Y`, to the default `VERSION_2A`. (This should not be a breaking change, even for those who already issued password with previous version, but as this package is not using the PHP implementation, it'd be logic to not have its specific version)
- Bump the version to 1.5.3.

Thanks.

Fix #33 